### PR TITLE
Crystal (partial) version of AutoinstIssues

### DIFF
--- a/crystal/shard.yml
+++ b/crystal/shard.yml
@@ -11,3 +11,4 @@ license: GPL
 development_dependencies:
   spectator:
     gitlab: arctic-fox/spectator
+    version: ~> 0.9.6

--- a/crystal/spec/autoinst_issues/exception_spec.cr
+++ b/crystal/spec/autoinst_issues/exception_spec.cr
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,13 +17,21 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-module Y3Storage
-  VERSION = "0.1.0"
-end
+require "../spec_helper"
 
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"
+Spectator.describe Y3Storage::AutoinstIssues::Exception do
+  subject(:issue) { described_class.new(error) }
+  let(:error) { Exception.new("error message") }
+
+  describe "#message" do
+    it "includes relevant information" do
+      expect(issue.message).to match(/A problem.*#{error.message}/)
+    end
+  end
+
+  describe "#severity" do
+    it "returns :fatal" do
+      expect(issue.severity).to eq(:fatal)
+    end
+  end
+end

--- a/crystal/spec/autoinst_issues/invalid_encryption_spec.cr
+++ b/crystal/spec/autoinst_issues/invalid_encryption_spec.cr
@@ -1,0 +1,72 @@
+# Copyright (c) [2019-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "../spec_helper"
+
+Spectator.describe Y3Storage::AutoinstIssues::InvalidEncryption do
+  mock Y3Storage::AutoinstProfile::PartitionSection do
+    stub crypt_method
+  end
+
+  let(:crypt_method) { :luks1 }
+  let(:reason) { :unknown }
+  let(:section) { Y3Storage::AutoinstProfile::PartitionSection.new }
+
+  subject(:issue) { described_class.new(section, reason) }
+
+  before_each { allow(section).to receive(:crypt_method).and_return crypt_method }
+
+  describe "#message" do
+    context "when method is unknown" do
+      let(:reason) { :unknown }
+      let(:crypt_method) { :foo }
+
+      it "warns about the method being unknown" do
+        message = issue.message
+        expect(message).to match(/'foo' is not a known/)
+      end
+    end
+
+    context "when method is unavailable" do
+      let(:reason) { :unavailable }
+      let(:crypt_method) { :pervasive_luks2 }
+
+      it "warns about the method not being available" do
+        message = issue.message
+        expect(message).to match(/'pervasive_luks2' is not available/)
+      end
+    end
+
+    context "when method is unsuitable" do
+      let(:reason) { :unsuitable }
+      let(:crypt_method) { :pervasive_luks2 }
+
+      it "warns about the method not being suitable" do
+        message = issue.message
+        expect(message).to match(/'pervasive_luks2' is not a suitable/)
+      end
+    end
+  end
+
+  describe "#severity" do
+    it "returns :fatal" do
+      expect(issue.severity).to eq(:fatal)
+    end
+  end
+end

--- a/crystal/spec/autoinst_issues/invalid_value_spec.cr
+++ b/crystal/spec/autoinst_issues/invalid_value_spec.cr
@@ -1,0 +1,66 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "../spec_helper"
+
+Spectator.describe Y3Storage::AutoinstIssues::InvalidValue do
+  mock Y3Storage::AutoinstProfile::PartitionSection do
+    stub size { "auto" }
+  end
+
+  subject(:issue) { described_class.new(section, :size, "auto") }
+
+  let(:section) { Y3Storage::AutoinstProfile::PartitionSection.new }
+
+  describe "#message" do
+    it "includes relevant information" do
+      message = issue.message
+      expect(message).to contain "size"
+      expect(message).to contain "auto"
+    end
+
+    context "when no new value was given" do
+      it "includes a warning about the section being skipped" do
+        expect(issue.message).to contain "the section will be skipped"
+      end
+    end
+
+    context "when a new value was given" do
+      subject(:issue) { described_class.new(section, :size, "auto", "some-value") }
+
+      it "includes a warning about the section being skipped" do
+        expect(issue.message).to contain "replaced by 'some-value'"
+      end
+    end
+
+    context "when :skip is given as new value" do
+      subject(:issue) { described_class.new(section, :size, "auto", :skip) }
+
+      it "includes a warning about the section being skipped" do
+        expect(issue.message).to contain "the section will be skipped"
+      end
+    end
+  end
+
+  describe "#severity" do
+    it "returns :warn" do
+      expect(issue.severity).to eq(:warn)
+    end
+  end
+end

--- a/crystal/spec/autoinst_issues/issue_spec.cr
+++ b/crystal/spec/autoinst_issues/issue_spec.cr
@@ -1,0 +1,94 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "../spec_helper"
+
+Spectator.describe Y3Storage::AutoinstIssues::Issue do
+  subject(:issue) { described_class.new }
+
+  describe "#message" do
+    it "raises a NotImplementedError exception" do
+      expect { issue.message }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#severity" do
+    it "raises a NotImplementedError exception" do
+      expect { issue.severity }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "#warn?" do
+    # We have to use a subclass here. If we stub Issue we get a
+    # "The return type of stub #severity : Symbol doesn't match the expected type NoReturn"
+    # That's caused because the implementation of Issue#severity only contains
+    # the "raise" sentence. It never actually returns a symbol.
+    mock Y3Storage::AutoinstIssues::MissingRoot do
+      stub severity : Symbol
+    end
+
+    subject(:issue) { Y3Storage::AutoinstIssues::MissingRoot.new }
+
+    before_each do
+      allow(issue).to receive(:severity).and_return(severity)
+    end
+    let(:severity) { :warn }
+
+    context "when severity is :warn" do
+      let(:severity) { :warn }
+
+      it "returns true" do
+        expect(issue).to be_warn
+      end
+    end
+
+    context "when severity is not :warn" do
+      let(:severity) { :fatal }
+
+      it "returns false" do
+        expect(issue).to_not be_warn
+      end
+    end
+  end
+
+  describe "#fatal?" do
+    subject(:issue) { Y3Storage::AutoinstIssues::MissingRoot.new }
+
+    before_each do
+      allow(issue).to receive(:severity).and_return(severity)
+    end
+    let(:severity) { :warn }
+
+    context "when severity is :fatal" do
+      let(:severity) { :fatal }
+
+      it "returns true" do
+        expect(issue).to be_fatal
+      end
+    end
+
+    context "when severity is not :fatal" do
+      let(:severity) { :warn }
+
+      it "returns false" do
+        expect(issue).to_not be_fatal
+      end
+    end
+  end
+end

--- a/crystal/spec/autoinst_issues/list_spec.cr
+++ b/crystal/spec/autoinst_issues/list_spec.cr
@@ -1,0 +1,94 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "../spec_helper"
+
+Spectator.describe Y3Storage::AutoinstIssues::List do
+  subject(:list) { described_class.new }
+  let(:section) { Y3Storage::AutoinstProfile::SkipListSection.new }
+
+  describe "#add" do
+    it "adds a new issue to the list" do
+      list.add(:exception, NilAssertionError.new)
+      expect(list.to_a).to all(be_an(Y3Storage::AutoinstIssues::Exception))
+    end
+
+    mock Y3Storage::AutoinstIssues::InvalidValue do
+      stub self.new(*args)
+    end
+
+    it "pass extra arguments to issue instance constructor" do
+      expect(Y3Storage::AutoinstIssues::InvalidValue).to receive(:new).with(section, :size, "value")
+      list.add(:invalid_value, section, :size, "value")
+    end
+  end
+
+  describe "#to_a" do
+    context "when list is empty" do
+      it "returns an empty array" do
+        expect(list.to_a).to eq([] of Y3Storage::AutoinstIssues::Issue)
+      end
+    end
+
+    context "when some issue was added" do
+      before_each do
+        2.times { list.add(:exception, NilAssertionError.new) }
+      end
+
+      it "returns an array containing added issues" do
+        expect(list.to_a).to all(be_a(Y3Storage::AutoinstIssues::Exception))
+        expect(list.to_a.size).to eq(2)
+      end
+    end
+  end
+
+  describe "#empty?" do
+    context "when list is empty" do
+      it "returns true" do
+        expect(list).to be_empty
+      end
+    end
+
+    context "when some issue was added" do
+      before_each { list.add(:exception, NilAssertionError.new) }
+
+      it "returns false" do
+        expect(list).to_not be_empty
+      end
+    end
+  end
+
+  describe "#fatal?" do
+    context "when contains some fatal error" do
+      before_each { list.add(:missing_root) }
+
+      it "returns true" do
+        expect(list).to be_fatal
+      end
+    end
+
+    context "when contains some fatal error" do
+      before_each { list.add(:invalid_value, section, :size, "value") }
+
+      it "returns false" do
+        expect(list).to_not be_fatal
+      end
+    end
+  end
+end

--- a/crystal/spec/autoinst_issues/missing_root_spec.cr
+++ b/crystal/spec/autoinst_issues/missing_root_spec.cr
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,13 +17,20 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-module Y3Storage
-  VERSION = "0.1.0"
-end
+require "../spec_helper"
 
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"
+Spectator.describe Y3Storage::AutoinstIssues::MissingRoot do
+  subject(:issue) { described_class.new }
+
+  describe "#message" do
+    it "returns a description of the issue" do
+      expect(issue.message).to contain "No root partition"
+    end
+  end
+
+  describe "#severity" do
+    it "returns :fatal" do
+      expect(issue.severity).to eq(:fatal)
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues.cr
+++ b/crystal/src/y3storage/autoinst_issues.cr
@@ -1,0 +1,40 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y3Storage
+  # Y3Storage::AutoinstIssues offers an API to register and report storage
+  # related AutoYaST problems.
+  #
+  # Basically, it works by registering found problems when creating the
+  # partitioning proposal (based on AutoYaST profile) and displaying them to
+  # the user. Check `Y3Storage::AutoinstIssues::Issue` in order to
+  # find out more details about the kind of problems.
+  #
+  # About registering errors, an instance of the
+  # `Y3Storage::AutoinstIssues::List` will be used.
+  module AutoinstIssues
+  end
+end
+
+require "./autoinst_issues/list"
+require "./autoinst_issues/issue"
+require "./autoinst_issues/exception"
+require "./autoinst_issues/invalid_encryption"
+require "./autoinst_issues/invalid_value"
+require "./autoinst_issues/missing_root"

--- a/crystal/src/y3storage/autoinst_issues/exception.cr
+++ b/crystal/src/y3storage/autoinst_issues/exception.cr
@@ -1,0 +1,69 @@
+# Copyright (c) [2019-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "./issue"
+
+module Y3Storage
+  module AutoinstIssues
+    # Represents a problem that occurs when an exception is raised.
+    #
+    # This error is used as a fallback for any problem that arises during
+    # proposal which is not handled in an specific way. It includes the
+    # exception which caused the problem to be registered.
+    #
+    # Example: registering an exception
+    #     begin
+    #       do_stuff # some exception is raised
+    #     rescue e : SomeException
+    #       new Y3Storage::AutoinstIssues::Exception.new(e)
+    #     end
+    class Exception < Issue
+      # Exception that was rescued
+      getter error : ::Exception
+
+      # Constructor
+      #
+      # Gets only one argument of type `::Exception`
+      def initialize(*args)
+        first = args[0]?
+        if first && first.is_a?(::Exception)
+          @error = first
+        else
+          raise ArgumentError.new("Wrong initialization: #{args}")
+        end
+      end
+
+      # Return problem severity
+      #
+      # Returns `Symbol` :fatal
+      # See `Issue#severity`
+      def severity
+        :fatal
+      end
+
+      # Return the error message to be displayed
+      #
+      # Returns `String` Error message
+      # See `Issue#message`
+      def message
+        "A problem ocurred while creating the partitioning plan: %s" % error.message
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues/exception.cr
+++ b/crystal/src/y3storage/autoinst_issues/exception.cr
@@ -42,6 +42,9 @@ module Y3Storage
       # Gets only one argument of type `::Exception`
       def initialize(*args)
         first = args[0]?
+
+        # See `Issue#initialize` for an explanation about why this manual validation is needed
+        # instead of declaring the arguments of `#initialize` more explicitly
         if first && first.is_a?(::Exception)
           @error = first
         else

--- a/crystal/src/y3storage/autoinst_issues/invalid_encryption.cr
+++ b/crystal/src/y3storage/autoinst_issues/invalid_encryption.cr
@@ -58,6 +58,9 @@ module Y3Storage
       def initialize(*args)
         first = args[0]?
         second = args[1]?
+
+        # See `Issue#initialize` for an explanation about why this manual validation is needed
+        # instead of declaring the arguments of `#initialize` more explicitly
         if first.is_a?(typeof(@section)) && second.is_a?(typeof(@reason))
           @section = first
           @reason = second

--- a/crystal/src/y3storage/autoinst_issues/invalid_encryption.cr
+++ b/crystal/src/y3storage/autoinst_issues/invalid_encryption.cr
@@ -1,0 +1,102 @@
+# Copyright (c) [2019-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "./issue"
+
+module Y3Storage
+  module AutoinstIssues
+    # Represents a problem with encryption settings
+    #
+    # This issues are considered 'fatal' because they might lead to a situation
+    # where a device is not unencrypted as it was intended.
+    #
+    # Example: the encryption method is not available in the running system
+    #     hash = { "crypt_method" => :pervasive_luks2 }
+    #     section = AutoinstProfile::PartitionSection.new_from_hashes(hash)
+    #     issue = InvalidEncryption.new(section, :unavailable)
+    #
+    # Example: the encryption method is unknown
+    #     hash = { "crypt_method" => :foo }
+    #     section = AutoinstProfile::PartitionSection.new_from_hashes(hash)
+    #     issue = InvalidEncryption.new(section, :unknown)
+    #
+    # Example: the encryption method is not suitable for the device
+    #     hash = { "mount" => "/", "crypt_method" => :random_swap }
+    #     section = AutoinstProfile::PartitionSection.new_from_hashes(hash)
+    #     issue = InvalidEncryption.new(section, :unsuitable)
+    class InvalidEncryption < Issue
+      # Section where it was detected (see {AutoinstProfile})
+      getter section : AutoinstProfile::PartitionSection
+      # Reason which causes the encryption to be invalid
+      getter reason : Symbol
+
+      # Constructor
+      #
+      # Gets several arguments
+      #
+      #   * `section` Section where it was detected (see `AutoinstProfile`)
+      #   * `reason`  Reason which casues the encryption to be invalid (as Symbol)
+      #     * :unknown when the method is unknown;
+      #     * :unavailable when the method is not available,
+      #     * :unsuitable when the method is not suitable for the device
+      def initialize(*args)
+        first = args[0]?
+        second = args[1]?
+        if first.is_a?(typeof(@section)) && second.is_a?(typeof(@reason))
+          @section = first
+          @reason = second
+        else
+          raise ArgumentError.new("Wrong initialization: #{args}")
+        end
+      end
+
+      # Return problem severity
+      #
+      # Returns `Symbol` :fatal
+      # See `Issue#severity`
+      def severity
+        :fatal
+      end
+
+      # Return the error message to be displayed
+      #
+      # Returns `String` Error message
+      # See `Issue#message`
+      def message
+        case reason
+        when :unavailable
+          # TRANSLATORS: 'crypt_method' is the name of the method to encrypt the device (like
+          # 'luks1' or 'random_swap').
+          "Encryption method '%{crypt_method}' is not available in this system." %
+            {crypt_method: section.crypt_method}
+        when :unknown
+          # TRANSLATORS: 'crypt_method' is the name of the method to encrypt the device (like
+          # 'luks1' or 'random_swap').
+          "'%{crypt_method}' is not a known encryption method." %
+            {crypt_method: section.crypt_method}
+        when :unsuitable
+          # TRANSLATORS: 'crypt_method' is the name of the method to encrypt the device (like
+          # 'luks1' or 'random_swap').
+          "'%{crypt_method}' is not a suitable method to encrypt the device." %
+            {crypt_method: section.crypt_method}
+        end
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues/invalid_value.cr
+++ b/crystal/src/y3storage/autoinst_issues/invalid_value.cr
@@ -54,6 +54,8 @@ module Y3Storage
         second = args[1]?
         third = args[2]?
 
+        # See `Issue#initialize` for an explanation about why this manual validation is needed
+        # instead of declaring the arguments of `#initialize` more explicitly
         if first.is_a?(typeof(@section)) && second.is_a?(Symbol) && third.is_a?(typeof(@value))
           @section = first
           @attr = second

--- a/crystal/src/y3storage/autoinst_issues/invalid_value.cr
+++ b/crystal/src/y3storage/autoinst_issues/invalid_value.cr
@@ -1,0 +1,103 @@
+# Copyright (c) [2019-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "./issue"
+
+module Y3Storage
+  module AutoinstIssues
+    # Represents an AutoYaST situation where an invalid value was given.
+    #
+    # Example: invalid value 'auto' for attribute :size on /home partition
+    #     section = AutoinstProfile::PartitioningSection.new_from_hashes({"size" => "auto"})
+    #     problem = InvalidValue.new(section, :size, section.size)
+    #     problem.value #=> "auto"
+    #     problem.attr  #=> :size
+    class InvalidValue < Issue
+      # Section where it was detected (see {AutoinstProfile})
+      getter section : AutoinstProfile::PartitionSection | AutoinstProfile::SkipListSection
+
+      # Name of the missing attribute
+      getter attr : Symbol
+
+      # Invalid value
+      getter value : Int64 | String
+
+      # New value or :skip to skip the section.
+      getter new_value : Int64 | String | Symbol
+
+      # Constructor
+      #
+      # Gets several arguments
+      #
+      #   * `section` Section where it was detected (see `AutoinstProfile`)
+      #   * `attr` Name of the invalid attribute (as symbol)
+      #   * `value` Invalid value
+      #   * `new_value` (optional) New value or :skip to skip the section
+      def initialize(*args)
+        first = args[0]?
+        second = args[1]?
+        third = args[2]?
+
+        if first.is_a?(typeof(@section)) && second.is_a?(Symbol) && third.is_a?(typeof(@value))
+          @section = first
+          @attr = second
+          @value = third
+
+          @new_value = args[3]? || :skip
+        else
+          raise ArgumentError.new("Wrong initialization: #{args}")
+        end
+      end
+
+      # Return problem severity
+      #
+      # Returns `Symbol` :warn
+      # See `Issue#severity`
+      def severity
+        :warn
+      end
+
+      # Return the error message to be displayed
+      #
+      # Returns `String` Error message
+      # See `Issue#message`
+      def message
+        # TRANSLATORS: 'value' is a generic value (number or string) 'attr' is an AutoYaST element
+        # name; 'new_value_message' is a short explanation about what should be done with the value.
+        "Invalid value '%{value}' for attribute '%{attr}' (%{new_value_message})." %
+          {
+            value:             value,
+            attr:              attr,
+            new_value_message: new_value_message,
+          }
+      end
+
+      # Return a messsage explaining what should be done with the value.
+      private def new_value_message
+        if new_value == :skip
+          # TRANSLATORS: it refers to an AutoYaST profile section
+          "the section will be skipped"
+        else
+          # TRANSLATORS: 'value' is the value for an AutoYaST element (a number or a string)
+          "replaced by '%{value}'" % {value: new_value}
+        end
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues/issue.cr
+++ b/crystal/src/y3storage/autoinst_issues/issue.cr
@@ -31,7 +31,10 @@ module Y3Storage
         nil
       end
 
-      # Subclass identified `type`
+      # Subclass identified by `type`
+      #
+      # In Ruby, `List#add` relies on `Y2Storage::AutoinstIssues.const_get`. Since there is no
+      # `cont_get` in Crystal, this class method is implemented to achieve a similar goal.
       def self.subclass(type)
         class_name = type.to_s.split("_").map(&.capitalize).join
 
@@ -40,6 +43,15 @@ module Y3Storage
         end
       end
 
+      # Constructor
+      #
+      # In the original Ruby code, each subclass of Issue has a completely different constructor
+      # with a completely different set of arguments. New objects are instantiated with a generic
+      # call like `calculated_class.new(*calculated_args)`... which couldn't be checked by Crystal
+      # at compilation if every constructor had a different signature.
+      #
+      # So we enforce the same signature `initialize(*args)` in all subclasses, which means we
+      # have to validate the passed arguments in the body of each constructor.
       def initialize(*args)
       end
 

--- a/crystal/src/y3storage/autoinst_issues/issue.cr
+++ b/crystal/src/y3storage/autoinst_issues/issue.cr
@@ -1,0 +1,84 @@
+# Copyright (c) [2019-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "../autoinst_profile"
+
+module Y3Storage
+  module AutoinstIssues
+    # Base class for storage-ng autoinstallation problems.
+    #
+    # `Y3Storage::AutoinstIssues` offers an API to register and report storage
+    # related AutoYaST problems.
+    class Issue
+      # Section where it was detected (see {AutoinstProfile})
+      def section
+        nil
+      end
+
+      # Subclass identified `type`
+      def self.subclass(type)
+        class_name = type.to_s.split("_").map(&.capitalize).join
+
+        {{@type.all_subclasses}}.find do |subclass|
+          subclass.name.split("::").last == class_name
+        end
+      end
+
+      def initialize(*args)
+      end
+
+      # Return problem severity
+      #
+      # * :fatal: abort the installation.
+      # * :warn:  display a warning.
+      #
+      # Returns `Symbol` Issue severity (:warn, :fatal)
+      # Raises NotImplementedError
+      def severity
+        raise NotImplementedError.new("#severity")
+      end
+
+      # Return the error message to be displayed
+      #
+      # Returns `String` Error message
+      # Raises NotImplementedError
+      def message
+        raise NotImplementedError.new("#message")
+      end
+
+      # Determines whether an error is fatal
+      #
+      # This is just a convenience method.
+      #
+      # Returns `Boolean`
+      def fatal?
+        severity == :fatal
+      end
+
+      # Determine whether an error is just a warning
+      #
+      # This is just a convenience method.
+      #
+      # Returns `Boolean`
+      def warn?
+        severity == :warn
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues/list.cr
+++ b/crystal/src/y3storage/autoinst_issues/list.cr
@@ -1,0 +1,85 @@
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "./issue"
+
+module Y3Storage
+  module AutoinstIssues
+    # List of storage related AutoYaST problems
+    #
+    # Example: Registering some problems
+    #     section = PartitionSection.new({})
+    #     list = List.new
+    #     list.add(:missing_root)
+    #     list.add(:invalid_value, section, :size, "auto")
+    #
+    # Example: Iterating through the list of problems
+    #     list.map(&:severity) #=> [:warn]
+    class List
+      include Enumerable(Issue)
+
+      delegate :each, :empty?, :<<, to: @items
+
+      # Constructor
+      def initialize
+        @items = [] of Issue
+      end
+
+      # Add a problem to the list
+      #
+      # The type of the problem is identified as a symbol which name is the
+      # underscore version of the class which implements it. For instance,
+      # `MissingRoot` would be referred as `:missing_root`.
+      #
+      # If a given type of problem requires some additional arguments, they
+      # should be added when calling this method. See the next example.
+      #
+      # Example: Adding a problem with additional arguments
+      #     list = List.new
+      #     list.add(:invalid_value, "/", :size, "auto")
+      #     list.empty? #=> false
+      #
+      # Param type       `Symbol` Issue type
+      # Param extra_args `Array` Additional arguments for the given problem
+      # Returns `Array<Issue>` List of problems
+      def add(type, *extra_args)
+        klass = Issue.subclass(type)
+        if klass
+          self << klass.new(*extra_args)
+        else
+          raise Error.new("Unknown AutoInstIssue type")
+        end
+      end
+
+      # Determine whether any of the problem on the list is fatal
+      #
+      # Returns `Boolean` true if any of them is a fatal problem
+      def fatal?
+        any?(&.fatal?)
+      end
+
+      # Returns an array containing registered problems
+      #
+      # Returns `Array<Issue>` List of problems
+      def to_a
+        @items
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_issues/missing_root.cr
+++ b/crystal/src/y3storage/autoinst_issues/missing_root.cr
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2017] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -17,13 +17,29 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
-module Y3Storage
-  VERSION = "0.1.0"
-end
+require "./issue"
 
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"
+module Y3Storage
+  module AutoinstIssues
+    # The proposal was successful but there is not root partition (/) defined.
+    #
+    # This is a fatal error because the installation is not possible.
+    class MissingRoot < Issue
+      # Return problem severity
+      #
+      # Returns `Symbol` :fatal
+      # See `Issue#severity`
+      def severity
+        :fatal
+      end
+
+      # Return the error message to be displayed
+      #
+      # Returns `String` Error message
+      # See `Issue#message`
+      def message
+        "No root partition (/) was found."
+      end
+    end
+  end
+end

--- a/crystal/src/y3storage/autoinst_profile.cr
+++ b/crystal/src/y3storage/autoinst_profile.cr
@@ -1,4 +1,4 @@
-# Copyright (c) [2016-2017] SUSE LLC
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,12 +18,14 @@
 # find current contact information at www.suse.com.
 
 module Y3Storage
-  VERSION = "0.1.0"
+  # Namespace adding an OOP layer on top of the <partitioning> section of the
+  # AutoYaST profile and its subsections.
+  #
+  # At some point, it would probably make sense to move all the contained
+  # classes from Y2Storage to AutoYaST.
+  module AutoinstProfile
+  end
 end
 
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"
+require "./autoinst_profile/partition_section"
+require "./autoinst_profile/skip_list_section"

--- a/crystal/src/y3storage/autoinst_profile/partition_section.cr
+++ b/crystal/src/y3storage/autoinst_profile/partition_section.cr
@@ -1,4 +1,5 @@
-# Copyright (c) [2016-2017] SUSE LLC
+#
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,12 +19,15 @@
 # find current contact information at www.suse.com.
 
 module Y3Storage
-  VERSION = "0.1.0"
+  module AutoinstProfile
+    # Thin object oriented layer on top of a <partition> section of the
+    # AutoYaST profile.
+    #
+    # So far, this class is only a placeholder needed to port AutoinstIssue
+    class PartitionSection
+      def crypt_method
+        :luks1
+      end
+    end
+  end
 end
-
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"

--- a/crystal/src/y3storage/autoinst_profile/skip_list_section.cr
+++ b/crystal/src/y3storage/autoinst_profile/skip_list_section.cr
@@ -1,4 +1,5 @@
-# Copyright (c) [2016-2017] SUSE LLC
+#
+# Copyright (c) [2017-2020] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -18,12 +19,11 @@
 # find current contact information at www.suse.com.
 
 module Y3Storage
-  VERSION = "0.1.0"
+  module AutoinstProfile
+    # Devices skip list in a <drive> section of an AutoYaST profile.
+    #
+    # So far, this class is only a placeholder needed to port AutoinstIssue
+    class SkipListSection
+    end
+  end
 end
-
-require "./y3storage/exceptions"
-require "./y3storage/disk_size"
-require "./y3storage/autoinst_profile"
-require "./y3storage/autoinst_issues"
-require "./y3storage/refinements"
-require "./y3storage/secret_attributes"

--- a/ruby/src/lib/y2storage/autoinst_issues/could_not_calculate_boot.rb
+++ b/ruby/src/lib/y2storage/autoinst_issues/could_not_calculate_boot.rb
@@ -23,10 +23,6 @@ module Y2Storage
   module AutoinstIssues
     # It was not possible to find a way to make the system bootable
     class CouldNotCalculateBoot < Issue
-      def initialize(*args)
-        super
-      end
-
       # Fatal problem
       #
       # @return [Symbol] :warn

--- a/ruby/src/lib/y2storage/autoinst_issues/missing_root.rb
+++ b/ruby/src/lib/y2storage/autoinst_issues/missing_root.rb
@@ -25,10 +25,6 @@ module Y2Storage
     #
     # This is a fatal error because the installation is not possible.
     class MissingRoot < Issue
-      def initialize(*args)
-        super
-      end
-
       # Return problem severity
       #
       # @return [Symbol] :fatal

--- a/ruby/src/lib/y2storage/autoinst_issues/no_disk_space.rb
+++ b/ruby/src/lib/y2storage/autoinst_issues/no_disk_space.rb
@@ -23,10 +23,6 @@ module Y2Storage
   module AutoinstIssues
     # There is no enough disk space to build the storage proposal
     class NoDiskSpace < Issue
-      def initialize(*args)
-        super
-      end
-
       # Fatal problem
       #
       # @return [Symbol] :fatal

--- a/ruby/src/lib/y2storage/autoinst_issues/no_proposal.rb
+++ b/ruby/src/lib/y2storage/autoinst_issues/no_proposal.rb
@@ -23,10 +23,6 @@ module Y2Storage
   module AutoinstIssues
     # Represents a problem that occurs when no proposal is possible
     class NoProposal < Issue
-      def initialize(*args)
-        super
-      end
-
       # Return problem severity
       #
       # @return [Symbol] :fatal


### PR DESCRIPTION
This is the first step to implement #3 

In fact it does not migrate every single subclass of `AutoinstIssues::Issue`, but migrating the rest would be now a mechanical work. All the difficult stuff should be already here.

Some things worth mentioning:

- In Ruby, `List.add` relies on `Y2Storage::AutoinstIssues.const_get`. There is no `cont_get` in Crystal, so I implemented a class method `Issue.subclass` using metaprogramming.
- I had to adapt the constructors of all the subclasses of `Issue` to make sure they all have the same signature. For that, I had to use `initialize(*args)` in all cases and then validate the arguments in the body of the constructor. Maybe is not very Crystal-like, but it's likely the only way to adapt the original Ruby code, that was VERY dynamic.
- I also had to modify how `InvalidValue` works. In Ruby, it accepts any kind of attribute and it uses `send` to get the value of the attribute. In Crystal, I had to limit the types of the attribute to `String` or `Int` (those were the types documented in the Ruby version) and I had to modify the API so the value is provided to the constructor by the caller.